### PR TITLE
Erin's Viera

### DIFF
--- a/Patches/Erin's Viera/PawnKinds.xml
+++ b/Patches/Erin's Viera/PawnKinds.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Erin's Viera</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+      <!-- ========== Give ammo to pawns. ========== -->
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/PawnKindDef[@Name="ERN_VieraTribalBase"] </xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>12</min>
+              <max>20</max>
+            </primaryMagazineCount>
+            <sidearms>
+              <li>
+                <sidearmMoney>
+                  <min>100</min>
+                  <max>600</max>
+                </sidearmMoney>
+                <weaponTags>
+                  <li>NeolithicMeleeBasic</li>
+                </weaponTags>
+              </li>
+            </sidearms>
+          </li>       
+        </value>
+      </li>
+
+      <li Class="PatchOperationAddModExtension">
+        <xpath>/Defs/PawnKindDef[
+        @Name="ERN_MercenaryMercenaryBase" or
+        @Name="ERN_VieraOutlanderBase" or 
+        @Name="ERN_VieraPirateBase" or
+        @Name="ERN_MercenaryMidTierBase" or
+        defName="ERN_VieraAncientSoldier"
+        ]</xpath>
+        <value>
+          <li Class="CombatExtended.LoadoutPropertiesExtension">
+            <primaryMagazineCount>
+              <min>5</min>
+              <max>8</max>
+            </primaryMagazineCount>
+          </li>
+        </value>
+      </li>
+
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/Patches/Erin's Viera/Race_Viera.xml
+++ b/Patches/Erin's Viera/Race_Viera.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Erin's Viera</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <operations>
+
+        <li Class="PatchOperationAddModExtension">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]</xpath>
+          <value>
+            <li Class="CombatExtended.RacePropertiesExtensionCE">
+              <bodyShape>Humanoid</bodyShape>
+            </li>
+          </value>
+        </li>
+
+        <li Class="PatchOperationConditional">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]/comps</xpath>
+          <nomatch Class="PatchOperationAdd">
+            <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]</xpath>
+            <value>
+              <comps />
+            </value>
+          </nomatch>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]/statBases</xpath>
+          <value>
+            <MeleeDodgeChance>1</MeleeDodgeChance>
+            <MeleeCritChance>1</MeleeCritChance>
+            <MeleeParryChance>1</MeleeParryChance>
+            <CarryWeight>35</CarryWeight>
+            <CarryBulk>20</CarryBulk>
+          </value>
+        </li>
+
+        <li Class="PatchOperationReplace">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]/tools</xpath>
+          <value>
+            <tools>
+              <li Class="CombatExtended.ToolCE">
+                <label>left fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>right fist</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>1</power>
+                <cooldownTime>1.26</cooldownTime>
+                <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
+                <armorPenetrationBlunt>0.250</armorPenetrationBlunt>
+              </li>
+              <li Class="CombatExtended.ToolCE">
+                <label>head</label>
+                <capacities>
+                  <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>4.49</cooldownTime>
+                <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
+                <chanceFactor>0.2</chanceFactor>
+                <armorPenetrationBlunt>0.625</armorPenetrationBlunt>
+              </li>
+            </tools>
+          </value>
+        </li>
+
+        <li Class="PatchOperationAdd">
+          <xpath>/Defs/AlienRace.ThingDef_AlienRace[defName="ERN_Viera"]/comps</xpath>
+          <value>
+            <li>
+              <compClass>CombatExtended.CompPawnGizmo</compClass>
+            </li>
+            <li Class="CombatExtended.CompProperties_Suppressable" />
+          </value>
+        </li>
+
+      </operations>
+    </match>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
Patch created using previous patch for Erin's Au Ra as a base

## Additions
-No new additions

## Changes

Using patch for Erin's Au Ra as a base, no changes needed beyond @Name and defName changes to Viera

## Reasoning

Why did you choose to implement things this way, e.g.
- No changes to stats for any melee attacks as default Viera has the same combat stats as an Au Ra without the extra body parts

## Testing

Check tests you have performed:
- [✓] Compiles without warnings
- [ ] Game runs without errors - somehow getting errors involving missing diffs for VFEM. No errors associated with CE or Viera
- [✓] Playtested a colony (10 minutes using Character Editor and Dev Tools to spawn raids, cause injuries, and give weapons and ammo)

In testing, race spawns within raids as normal within factions they should spawn in. They have correct gear and ammo for their gear.
