### PR TITLE
Patching Kerberos Protect Gears and Firearms

### DIFF
--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -26,13 +26,15 @@
 		<li IfModActive="EV.all.tech.melee">ModPatches/All-Tech Melee</li>
 		<li IfModActive="sarg.alphaanimals">ModPatches/Alpha Animals</li>
 		<li IfModActive="sarg.alphabiomes">ModPatches/Alpha Biomes</li>
+		<li IfModActive="sarg.alphabooks">ModPatches/Alpha Books</li>
 		<li IfModActive="sarg.alphagenes">ModPatches/Alpha Genes</li>
 		<li IfModActive="sarg.alphaimplants">ModPatches/Alpha Implants</li>
 		<li IfModActive="sarg.alphamechs">ModPatches/Alpha Mechs</li>
 		<li IfModActive="Sarg.AlphaMemes">ModPatches/Alpha Memes</li>
 		<li IfModActive="sarg.magicalmenagerie">ModPatches/Alpha Mythology</li>
 		<li IfModActive="sarg.alphaships">ModPatches/Alpha Ships</li>
-		<li IfModActive="sarg.alphavehiclesneolithic">ModPatches/Alpha Vehicle</li>
+		<li IfModActive="sarg.alphavehiclesneolithic">ModPatches/Alpha Vehicles/Neolithic</li>
+		<li IfModActive="sarg.alphavehiclesageofsail">ModPatches/Alpha Vehicles/Age of Sail</li>
 		<li IfModActive="hlx.UltratechAlteredCarbon">ModPatches/Altered Carbon Ultratech Unleashed</li>
 		<li IfModActive="aa.warcaskets.rw">ModPatches/Ancient Arsenal Warcaskets</li>
 		<li IfModActive="bbbbilly.ancientbladecyborg">ModPatches/Ancient Blade Cyborg</li>
@@ -55,7 +57,7 @@
 		<li IfModActive="Shinzy.Apparello">ModPatches/Apparello</li>
 		<li IfModActive="scpchemfuel.appliances">ModPatches/Appliances Expanded</li>
 		<li IfModActive="AR13S.Arachne1point0, Mlie.ArachneRace">ModPatches/Arachne</li>
-		<li IfModActive="ALIEN.ArasakaCorporation">ModPatches/Arasaka Corporation [1.3]</li>
+		<li IfModActive="ALIEN.ArasakaCorporation">ModPatches/Arasaka Corporation</li>
 		<li IfModActive="Teok25.ArchotechExpanded">ModPatches/Archotech Expanded</li>
 		<li IfModActive="Teok25.ArchotechExpanded.Prosthetics">ModPatches/Archotech Expanded Prosthetics</li>
 		<li IfModActive="New.ArchotechPowerArmor">ModPatches/Archotech PowerArmor</li>
@@ -69,6 +71,7 @@
 		<li IfModActive="Odz.40k.ImperialGuard.DKOK">ModPatches/Astra Militarum Regimentum - Krieg</li>
 		<li IfModActive="Knorke.40k.ImperialGuard.DKOK.OfficerHelmet">ModPatches/Astra Militarum Regimentum - Krieg Officer Helmet</li>
 		<li IfModActive="Flyingstar.AutoMortarsUnofficial">ModPatches/Auto-Mortars</li>
+		<li IfModActive="veltaris.mechtech">ModPatches/AV Mechtech</li>
 		<li IfModActive="veltaris.mechqueen">ModPatches/AV Work Queen</li>
 		<li IfModActive="automatic.autocleaner">ModPatches/Autocleaner</li>
 		<li IfModActive="Heymyteamrules.BeastManTribes">ModPatches/Beast Man Tribes</li>
@@ -85,6 +88,7 @@
 		<li IfModActive="Ushanka.BiologicalWarfare">ModPatches/BiologicalWarfare</li>
 		<li IfModActive="BiomesTeam.BiomesCaverns">ModPatches/Biomes Caverns</li>
 		<li IfModActive="BiomesTeam.BiomesCore">ModPatches/Biomes Core</li>
+		<li IfModActive="BiomesTeam.BiomesPollutedLands">ModPatches/Biomes Polluted Lands</li>
 		<li IfModActive="biotexpans.insect">ModPatches/Biotech Expansion - Insectoid</li>
 		<li IfModActive="biotexpans.mammalia">ModPatches/Biotech Expansion - Mammalia</li>
 		<li IfModActive="biotexpans.mythic">ModPatches/Biotech Expansion - Mythic</li>
@@ -114,7 +118,7 @@
 		<li IfModActive="Jewsader.Cossacks.Rimworld_copy">ModPatches/Cossacks of the Rim</li>
 		<li IfModActive="Canon.CrownsandRegalia">ModPatches/Crowns and Regalia</li>
 		<li IfModActive="Mlie.CuprosAlloys">ModPatches/CuprosAlloys</li>
-		<li IfModActive="DanDMan.CursedGuns">ModPatches/Cursed Guns</li>
+		<li IfModActive="MyLegsAreOkay.CursedGunsReUp">ModPatches/Cursed Guns</li>
 		<li IfModActive="K.CyberNet">ModPatches/Cybernet</li>
 		<li IfModActive="kikohi.cybernetic">ModPatches/Cybernetic Organism and Neural Network</li>
 		<li IfModActive="Mlie.CyberneticWarfare">ModPatches/Cybernetic Warfare and Special Weapons</li>
@@ -210,9 +214,11 @@
 		<li IfModActive="Grimworld.Autoguns">ModPatches/Grimworld Autoguns</li>		
 		<li IfModActive="Grimworld.Core">ModPatches/Grimworld Core Imperialis</li>	
 		<li IfModActive="Grimworld.AstraMilitarum">ModPatches/GrimWorld Hammer of the Imperium</li>
+		<li IfModActive="Grimworld.Iron">ModPatches/GrimWorld Heresy Addon</li>		
 		<li IfModActive="Grimworld.Vehicles">ModPatches/GrimWorld Imperial Vehicles</li>
 		<li IfModActive="Grimworld.Lasguns">ModPatches/Grimworld Lasguns</li>
 		<li IfModActive="Grimworld.Melee">ModPatches/Grimworld Melee</li>
+		<li IfModActive="grimworld.scatteredsons">ModPatches/GrimWorld Scattered Sons</li>		
 		<li IfModActive="grimworld.talonOfTheEmperor">ModPatches/GrimWorld Talons of the Emperor</li>
 		<li IfModActive="TenMoe.GFCL">ModPatches/Girls Frontline Apparel Pack</li>
 		<li IfModActive="RicoFox233.GirlsFrontline.404Team">ModPatches/Girls Frontline Styles 404 Team</li>
@@ -225,13 +231,13 @@
 		<li IfModActive="pphhyy.Gulden">ModPatches/Gulden Mod</li>
 		<li IfModActive="Monti.HalfDragons">ModPatches/Half Dragons</li>
 		<li IfModActive="HLX.RimworldUNSCArmoury">ModPatches/Halo - UNSC Armoury</li>
-		<li IfModActive="TheInfinityIQ.Halo.UNSC_copy">ModPatches/Halo Ammo</li>
-		<li IfModActive="TheInfinityIQ.Halo.UNSC_copy">ModPatches/Halo UNSC Weapon Pack</li>
+		<li IfModActive="TheInfinityIQ.Halo.UNSC">ModPatches/Halo UNSC Weapon Pack</li>
 		<li IfModActive="PitchStone.HeavyMeleeWeapons, Mlie.HeavyMeleeWeapons">ModPatches/Heavy Melee Weapons</li>
 		<li IfModActive="Bando.Heyrathehorned">ModPatches/Heyra the Horned</li>
 		<li IfModActive="zal.highcaliber">ModPatches/High Caliber</li>
 		<li IfModActive="Mlie.HighTechLaboratoryFacilities">ModPatches/High Tech Laboratory Facilities</li>
 		<li IfModActive="Hive.Armory.Geminingen">ModPatches/Hive Armory</li>
+		<li IfModActive="odz.huscarlpowerarmor">ModPatches/Huscarl - Power Armor</li>
 		<li IfModActive="zal.hyena">ModPatches/Hyena (Continued)</li>
 		<li IfModActive="Ayameduki.HARIdhale">ModPatches/Idhale Race</li>
 		<li IfModActive="detvisor.impactweaponry">ModPatches/Impact Weaponry</li>
@@ -242,6 +248,7 @@
 		<li IfModActive="jemlpro.Infusion2Expansion">ModPatches/Infused 2 Expansion</li>
 		<li IfModActive="latta.infusion">ModPatches/Infusion 2</li>
 		<li IfModActive="SirMashedPotato.InsectsHaveChitin">ModPatches/Insects have chitin</li>
+		<li IfModActive="lts.I">ModPatches/Integrated Implants</li>
 		<li IfModActive="EL.IonWeaponry">ModPatches/Ion Weaponry</li>
 		<li IfModActive="JangoDsoul.CastleWalls,gideon.castlewalls">ModPatches/JDS Castle Walls</li>
 		<li IfModActive="JangoDsoul.EFT.Apparel">ModPatches/JDS EFT Apparel</li>
@@ -264,6 +271,7 @@
 		<li IfModActive="ALIEN.KaiserArmory">ModPatches/Kaiser Armory</li>
 		<li IfModActive="psyche.kemomimihouse">ModPatches/Kemomimihouse</li>
 		<li IfModActive="Moo.kemomimihouse.Kz">ModPatches/kemomimihouse Kz</li>
+		<li IfModActive="BlackMarket420.Kerberos">ModPatches/Kerberos Protect Gears and Firearms</li>
 		<li IfModActive="Kenshi.Armory.Geminingen, biowreck.KenshiArmory">ModPatches/Kenshi Armory</li>
 		<li IfModActive="ssulunge.KijinRace3">ModPatches/Kijin 3.0</li>
 		<li IfModActive="RicoFox233.KLKApparel">ModPatches/Kill la Kill Styles Pack</li>
@@ -309,6 +317,7 @@
 		<li IfModActive="Mlie.MedicalSupplements">ModPatches/Medicine Supplements (Continued)</li>
 		<li IfModActive="JoeDaly.MedMeds.MO">ModPatches/Medieval Medicines 1.4 Medieval Overhaul Edition</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul">ModPatches/Medieval Overhaul</li>
+		<li IfModActive="Turkler.MedievalOverhaul.ArcaneArchaeologists">ModPatches/Medieval Overhaul Arcane Archaeologists</li>
 		<li IfModActive="pphhyy.BarbariansMOSubmod">ModPatches/Medieval Overhaul Barbarians</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul.House.Roxmont">ModPatches/Medieval Overhaul House Roxmont</li>
 		<li IfModActive="Arisher.Medieval.Tailor">ModPatches/Medieval Tailor</li>
@@ -342,7 +351,6 @@
 		<li IfModActive="SirMashedPotato.MorrowRim.AshSwamp">ModPatches/MorrowRim - Ashlands Swamp</li>
 		<li IfModActive="SirMashedPotato.MorrowRim.Bloodmoon">ModPatches/MorrowRim - Bloodmoon</li>
 		<li IfModActive="SirMashedPotato.MorrowRim.ColovianFurHelm">ModPatches/MorrowRim - Colovian Fur Helm</li>
-		<li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>
 		<li IfModActive="Nemonian.MYCartel">ModPatches/Moyo Cartel</li>
 		<li IfModActive="Nemonian.MY">ModPatches/Moyo from the depth</li>
 		<li IfModActive="AOBA.RedMoyo">ModPatches/Moyo light in the abyss</li>
@@ -358,9 +366,6 @@
 		<li IfModActive="neronix17.fr.content.dni">ModPatches/O21 Dragons Not Included</li>
 		<li IfModActive="neronix17.fr.compilation">ModPatches/O21 Forgotten Realms</li>
 		<li IfModActive="neronix17.mechadroids">ModPatches/O21 Mechadroids</li>
-		<li IfModActive="Neronix17.Outland.Core">ModPatches/O21 Outland - Core</li>
-		<li IfModActive="Neronix17.Outland.EastbornEmpire">ModPatches/O21 Outland - Eastborn</li>
-		<li IfModActive="Neronix17.Outland.MotzCoalition">ModPatches/O21 Outland - Motz Coalition</li>
 		<li IfModActive="Odz.WWII.Stalingrad.Uniforms">ModPatches/ODZ Stalingrad - Uniforms</li>
 		<li IfModActive="1.3.Odz.Suits">ModPatches/ODZ Suits</li>
 		<li IfModActive="ObsidiaExpansion.Xenos.Mothoids">ModPatches/Obsidia Expansion</li>
@@ -380,14 +385,17 @@
 		<li IfModActive="Mlie.OuterRimTatooine">ModPatches/Outer Rim - Tatooine</li>
 		<li IfModActive="Mlie.OuterRimTatooineSandcrawler">ModPatches/Outer Rim - Tatooine Sandcrawler</li>
 		<li IfModActive="Neronix17.Outland.Core">ModPatches/Outland - Core</li>
+		<li IfModActive="Neronix17.Outland.EastbornEmpire">ModPatches/Outland - Eastborn</li>
+		<li IfModActive="Neronix17.Outland.Genetics">ModPatches/Outland - Genetics</li>
+		<li IfModActive="Neronix17.Outland.MotzCoalition">ModPatches/Outland - Motz Coalition</li>		
 		<li IfModActive="Neronix17.Outland.RedburnPact">ModPatches/Outland - Redburn Pact</li>
 		<li IfModActive="riprusse.rfPalmCats">ModPatches/Palm Cats</li>
 		<li IfModActive="AhnDemi.PanieltheAutomata">ModPatches/Paniel the Automata</li>
 		<li IfModActive="shauaputa.pawnboldrace">ModPatches/Pawnbold Race</li>
 		<li IfModActive="Mlie.CutePenguin">ModPatches/Penguin</li>
 		<li IfModActive="Sov.WarcasketWeapons">ModPatches/Persona Warcasket Weapons</li>
-		<li IfModActive="Vanya.Polarisbloc.CoreLab">ModPatches/Polarisbloc Core Lab</li>
-		<li IfModActive="Vanya.Polarisbloc.SecurityForce">ModPatches/Polarisbloc Security Force</li>
+		<li IfModActive="Vanya.Polarisbloc.CoreLab,Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
+		<li IfModActive="Vanya.Polarisbloc.SecurityForce,Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="milk.poleepkwaupdate, GHOST.Poleepkwa">ModPatches/Poleepkwa Race</li>
 		<li IfModActive="BotchJob.PossessedWeapons">ModPatches/Possessed Weapons</li>
 		<li IfModActive="JangoDsoul.T45b.PowerArmor">ModPatches/PowerArmour T-45b</li>
@@ -417,6 +425,7 @@
 		<li IfModActive="CP.RimmuNation.2.Clothing">ModPatches/RH2 Rimmu-Nation² - Clothing</li>
 		<li IfModActive="CP.RimmuNation.2.Security">ModPatches/RH2 Rimmu-Nation² - Security</li>
 		<li IfModActive="CP.RimmuNation.2.Weapons">ModPatches/RH2 Rimmu-Nation² - Weapons</li>
+		<li IfModActive="MrSamuelStreamer.RPGAdventureFlavour">ModPatches/RPG Adventure Flavour Pack</li>
 		<li IfModActive="DanDMan.RSPABSWGASE">ModPatches/RW Pilas and Bows</li>
 		<li IfModActive="ravvy.DD.Void.Addon">ModPatches/RWY Dragon's Descent Void Dwellers</li>
 		<li IfModActive="RunneLatki.RabbieRaceMod">ModPatches/Rabbie The Moonrabbit</li>
@@ -427,11 +436,13 @@
 		<li IfModActive="jkviolet.rakkleracemode">ModPatches/Rakkle the Rattlesnake</li>
 		<li IfModActive="Mlie.RamboWeaponsPack">ModPatches/Rambo Weapons Pack</li>
 		<li IfModActive="Rin.RatkinApparel">ModPatches/Ratkin Apparel+</li>
+		<li IfModActive="SG.Ratkin">ModPatches/Ratkin Xenotype</li>
 		<li IfModActive="JangoDsoul.Ratnik3">ModPatches/Ratnik-3 Prototype Armor</li>
 		<li IfModActive="ReBuild.COTR.DoorsAndCorners">ModPatches/ReBuild - Doors and Corners</li>
 		<li IfModActive="ReGrowth.BOTR.Core">ModPatches/ReGrowth - Core</li>
 		<li IfModActive="ReGrowth.BOTR.ExtinctAnimalsPack">ModPatches/ReGrowth - Extinct Animals</li>
 		<li IfModActive="ReGrowth.BOTR.Wastelands">ModPatches/ReGrowth - Wastelands</li>
+		<li IfModActive="mlie.reinforcedmechanoid2">ModPatches/Reinforced Mechanoid 2</li>
 		<li IfModActive="Bonible.ReconMech">ModPatches/Recon Mechanoid</li>
 		<li IfModActive="Mlie.RedArmy">ModPatches/Red Army</li>
 		<li IfModActive="vonschtirlitz.RCA">ModPatches/Redcoat Apparel</li>
@@ -485,6 +496,7 @@
 		<li IfModActive="rimsenal.feral">ModPatches/Rimsenal Feral</li>
 		<li IfModActive="rimsenal.security">ModPatches/Rimsenal Security</li>
 		<li IfModActive="Rimsenal.Askbarn">ModPatches/Rimsenal Xenotype Pack - Askbarn</li>
+		<li IfModActive="Rimsenal.Harana">ModPatches/Rimsenal Xenotype Pack - Harana</li>
 		<li IfModActive="SirMashedPotato.DarkDescent">ModPatches/Rimworld - The Dark Descent</li>
 		<li IfModActive="Mlie.RRUESContactLightArmory">ModPatches/Risk of Rain UES Contact Light Armory</li>
 		<li IfModActive="Ghastly.RoboticServitude">ModPatches/Robotic Servitude</li>
@@ -520,6 +532,7 @@
 		<li IfModActive="Koni.Misc.SteamworldUniforms">ModPatches/Steamworld Uniforms</li>
 		<li IfModActive="Scurvyez.Bastyon">ModPatches/Steves Animals</li>
 		<li IfModActive="det.sbdelights">ModPatches/Stoneborn - Delights</li>
+		<li IfModActive="Artemiish.SupernaturalWeapons">ModPatches/Supernatural Weapons</li>
 		<li IfModActive="Mlie.Swords">ModPatches/Swords</li>
 		<li IfModActive="Trickity.Conversion.Staff">ModPatches/T's Conversion Staff</li>
 		<li IfModActive="Trickity.Samurai.Faction">ModPatches/T's Samurai Faction</li>
@@ -537,6 +550,7 @@
 		<li IfModActive="syrchalis.thrumkin">ModPatches/Thrumkin</li>
 		<li IfModActive="JAHV.SpacerVehiclesHAL.CONTINUED">Modpatches/Titan Vehicles</li>
 		<li IfModActive="Mlie.ToolmetricsRedux">ModPatches/Toolmetrics Redux</li>
+		<li IfModActive="TheSimpleDude42.ToolsOPlenty">ModPatches/Tools O'Plenty</li>
 		<li IfModActive="RicoFox233.TouhouStyle.ScarletDevil">ModPatches/TouhouStyle</li>
 		<li IfModActive="Gunmar.TribalWarriorSet">ModPatches/Tribal Warrior Set</li>
 		<li IfModActive="ALIEN.TsarArmory">ModPatches/Tsar Armory</li>
@@ -570,11 +584,10 @@
 		<li IfModActive="OskarPotocki.VFE.Empire">ModPatches/Vanilla Factions Expanded - Empire</li>
 		<li IfModActive="OskarPotocki.VFE.Insectoid2">ModPatches/Vanilla Factions Expanded - Insectoids 2</li>
 		<li IfModActive="OskarPotocki.VFE.Mechanoid">ModPatches/Vanilla Factions Expanded - Mechanoids</li>
-		<li IfModActive="OskarPotocki.VanillaFactionsExpanded.MedievalModule">ModPatches/Vanilla Factions Expanded - Medieval</li>
+		<li IfModActive="OskarPotocki.VFE.Medieval2">ModPatches/Vanilla Factions Expanded - Medieval 2</li>
 		<li IfModActive="OskarPotocki.VFE.Pirates">ModPatches/Vanilla Factions Expanded - Pirates</li>
 		<li IfModActive="OskarPotocki.VanillaFactionsExpanded.SettlersModule">ModPatches/Vanilla Factions Expanded - Settlers</li>
 		<li IfModActive="OskarPotocki.VFE.Tribals">ModPatches/Vanilla Factions Expanded - Tribals</li>
-		<li IfModActive="OskarPotocki.VFE.Vikings">ModPatches/Vanilla Factions Expanded - Vikings</li>
 		<li IfModActive="VanillaExpanded.VFESecurity">ModPatches/Vanilla Furniture Expanded - Security</li>
 		<li IfModActive="VanillaExpanded.VGeneticsE">ModPatches/Vanilla Genetics Expanded</li>
 		<li IfModActive="VanillaExpanded.Ideo.Dryads">ModPatches/Vanilla Ideology Expanded - Dryads</li>
@@ -582,6 +595,7 @@
 		<li IfModActive="VanillaExpanded.VMemesE">ModPatches/Vanilla Ideology Expanded - Memes and Structures</li>
 		<li IfModActive="VanillaExpanded.VPersonaWeaponsE">ModPatches/Vanilla Persona Weapons Expanded</li>
 		<li IfModActive="VanillaExpanded.VPlantsEMushrooms">ModPatches/Vanilla Plants Expanded - Mushrooms</li>
+		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="VanillaExpanded.VPsycastsE">ModPatches/Vanilla Psycasts Expanded</li>
 		<li IfModActive="VanillaExpanded.VPE.Hemosage">ModPatches/Vanilla Psycasts Expanded - Hemosage</li>
 		<li IfModActive="Chairheir.VPERunesmith">ModPatches/Vanilla Psycasts Expanded - Runesmith</li>
@@ -619,6 +633,7 @@
 		<li IfModActive="flangopink.VanillaXCOMPlasmaWeapons">ModPatches/Vanilla XCOM Plasma Weapons</li>
 		<li IfModActive="flangopink.VanillaXCOMWeapons">ModPatches/Vanilla XCOM Weapons</li>
 		<li IfModActive="KavaCaligula.VFClassicMechs">ModPatches/Vehicle Framework Expanded - Classic Mechs</li>
+		<li IfModActive="Gunmar.VictorianEraApparels">ModPatches/Victorian Era Apparels</li>
 		<li IfModActive="Mlie.VulpineRacePack">ModPatches/Vulpine Pack</li>
 		<li IfModActive="VsEdit.ods.wwiigerman.uniforms">ModPatches/WWII German Uniforms</li>
 		<li IfModActive="TheWingedGuy.WWII.Soviet.Faction">ModPatches/WWII Soviet Faction</li>
@@ -642,7 +657,6 @@
 		<li IfModActive="Ayameduki.HARXenoorca">ModPatches/Xenoorca Race</li>
 		<li IfModActive="MrKociak.YetAnotherProstheticExpansionModCore">ModPatches/YetAnotherProsthetics - Core</li>
 		<li IfModActive="brrainz.zombieland">ModPatches/Zombieland</li>
-		<li IfModActive="BlackMarket420.Kerberos">ModPatches/Kerberos Protect Gears and Firearms</li>
 		<!-- Mod Patches (Assemblies) -->
 		<li IfModActive="rwmt.Multiplayer">ModPatches/Multiplayer</li>
 		<li IfModActive="smashphil.neceros.srtsexpanded">ModPatches/SRTS</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -26,15 +26,13 @@
 		<li IfModActive="EV.all.tech.melee">ModPatches/All-Tech Melee</li>
 		<li IfModActive="sarg.alphaanimals">ModPatches/Alpha Animals</li>
 		<li IfModActive="sarg.alphabiomes">ModPatches/Alpha Biomes</li>
-		<li IfModActive="sarg.alphabooks">ModPatches/Alpha Books</li>
 		<li IfModActive="sarg.alphagenes">ModPatches/Alpha Genes</li>
 		<li IfModActive="sarg.alphaimplants">ModPatches/Alpha Implants</li>
 		<li IfModActive="sarg.alphamechs">ModPatches/Alpha Mechs</li>
 		<li IfModActive="Sarg.AlphaMemes">ModPatches/Alpha Memes</li>
 		<li IfModActive="sarg.magicalmenagerie">ModPatches/Alpha Mythology</li>
 		<li IfModActive="sarg.alphaships">ModPatches/Alpha Ships</li>
-		<li IfModActive="sarg.alphavehiclesneolithic">ModPatches/Alpha Vehicles/Neolithic</li>
-		<li IfModActive="sarg.alphavehiclesageofsail">ModPatches/Alpha Vehicles/Age of Sail</li>
+		<li IfModActive="sarg.alphavehiclesneolithic">ModPatches/Alpha Vehicle</li>
 		<li IfModActive="hlx.UltratechAlteredCarbon">ModPatches/Altered Carbon Ultratech Unleashed</li>
 		<li IfModActive="aa.warcaskets.rw">ModPatches/Ancient Arsenal Warcaskets</li>
 		<li IfModActive="bbbbilly.ancientbladecyborg">ModPatches/Ancient Blade Cyborg</li>
@@ -57,7 +55,7 @@
 		<li IfModActive="Shinzy.Apparello">ModPatches/Apparello</li>
 		<li IfModActive="scpchemfuel.appliances">ModPatches/Appliances Expanded</li>
 		<li IfModActive="AR13S.Arachne1point0, Mlie.ArachneRace">ModPatches/Arachne</li>
-		<li IfModActive="ALIEN.ArasakaCorporation">ModPatches/Arasaka Corporation</li>
+		<li IfModActive="ALIEN.ArasakaCorporation">ModPatches/Arasaka Corporation [1.3]</li>
 		<li IfModActive="Teok25.ArchotechExpanded">ModPatches/Archotech Expanded</li>
 		<li IfModActive="Teok25.ArchotechExpanded.Prosthetics">ModPatches/Archotech Expanded Prosthetics</li>
 		<li IfModActive="New.ArchotechPowerArmor">ModPatches/Archotech PowerArmor</li>
@@ -71,7 +69,6 @@
 		<li IfModActive="Odz.40k.ImperialGuard.DKOK">ModPatches/Astra Militarum Regimentum - Krieg</li>
 		<li IfModActive="Knorke.40k.ImperialGuard.DKOK.OfficerHelmet">ModPatches/Astra Militarum Regimentum - Krieg Officer Helmet</li>
 		<li IfModActive="Flyingstar.AutoMortarsUnofficial">ModPatches/Auto-Mortars</li>
-		<li IfModActive="veltaris.mechtech">ModPatches/AV Mechtech</li>
 		<li IfModActive="veltaris.mechqueen">ModPatches/AV Work Queen</li>
 		<li IfModActive="automatic.autocleaner">ModPatches/Autocleaner</li>
 		<li IfModActive="Heymyteamrules.BeastManTribes">ModPatches/Beast Man Tribes</li>
@@ -88,7 +85,6 @@
 		<li IfModActive="Ushanka.BiologicalWarfare">ModPatches/BiologicalWarfare</li>
 		<li IfModActive="BiomesTeam.BiomesCaverns">ModPatches/Biomes Caverns</li>
 		<li IfModActive="BiomesTeam.BiomesCore">ModPatches/Biomes Core</li>
-		<li IfModActive="BiomesTeam.BiomesPollutedLands">ModPatches/Biomes Polluted Lands</li>
 		<li IfModActive="biotexpans.insect">ModPatches/Biotech Expansion - Insectoid</li>
 		<li IfModActive="biotexpans.mammalia">ModPatches/Biotech Expansion - Mammalia</li>
 		<li IfModActive="biotexpans.mythic">ModPatches/Biotech Expansion - Mythic</li>
@@ -118,7 +114,7 @@
 		<li IfModActive="Jewsader.Cossacks.Rimworld_copy">ModPatches/Cossacks of the Rim</li>
 		<li IfModActive="Canon.CrownsandRegalia">ModPatches/Crowns and Regalia</li>
 		<li IfModActive="Mlie.CuprosAlloys">ModPatches/CuprosAlloys</li>
-		<li IfModActive="MyLegsAreOkay.CursedGunsReUp">ModPatches/Cursed Guns</li>
+		<li IfModActive="DanDMan.CursedGuns">ModPatches/Cursed Guns</li>
 		<li IfModActive="K.CyberNet">ModPatches/Cybernet</li>
 		<li IfModActive="kikohi.cybernetic">ModPatches/Cybernetic Organism and Neural Network</li>
 		<li IfModActive="Mlie.CyberneticWarfare">ModPatches/Cybernetic Warfare and Special Weapons</li>
@@ -214,11 +210,9 @@
 		<li IfModActive="Grimworld.Autoguns">ModPatches/Grimworld Autoguns</li>		
 		<li IfModActive="Grimworld.Core">ModPatches/Grimworld Core Imperialis</li>	
 		<li IfModActive="Grimworld.AstraMilitarum">ModPatches/GrimWorld Hammer of the Imperium</li>
-		<li IfModActive="Grimworld.Iron">ModPatches/GrimWorld Heresy Addon</li>		
 		<li IfModActive="Grimworld.Vehicles">ModPatches/GrimWorld Imperial Vehicles</li>
 		<li IfModActive="Grimworld.Lasguns">ModPatches/Grimworld Lasguns</li>
 		<li IfModActive="Grimworld.Melee">ModPatches/Grimworld Melee</li>
-		<li IfModActive="grimworld.scatteredsons">ModPatches/GrimWorld Scattered Sons</li>		
 		<li IfModActive="grimworld.talonOfTheEmperor">ModPatches/GrimWorld Talons of the Emperor</li>
 		<li IfModActive="TenMoe.GFCL">ModPatches/Girls Frontline Apparel Pack</li>
 		<li IfModActive="RicoFox233.GirlsFrontline.404Team">ModPatches/Girls Frontline Styles 404 Team</li>
@@ -231,13 +225,13 @@
 		<li IfModActive="pphhyy.Gulden">ModPatches/Gulden Mod</li>
 		<li IfModActive="Monti.HalfDragons">ModPatches/Half Dragons</li>
 		<li IfModActive="HLX.RimworldUNSCArmoury">ModPatches/Halo - UNSC Armoury</li>
-		<li IfModActive="TheInfinityIQ.Halo.UNSC">ModPatches/Halo UNSC Weapon Pack</li>
+		<li IfModActive="TheInfinityIQ.Halo.UNSC_copy">ModPatches/Halo Ammo</li>
+		<li IfModActive="TheInfinityIQ.Halo.UNSC_copy">ModPatches/Halo UNSC Weapon Pack</li>
 		<li IfModActive="PitchStone.HeavyMeleeWeapons, Mlie.HeavyMeleeWeapons">ModPatches/Heavy Melee Weapons</li>
 		<li IfModActive="Bando.Heyrathehorned">ModPatches/Heyra the Horned</li>
 		<li IfModActive="zal.highcaliber">ModPatches/High Caliber</li>
 		<li IfModActive="Mlie.HighTechLaboratoryFacilities">ModPatches/High Tech Laboratory Facilities</li>
 		<li IfModActive="Hive.Armory.Geminingen">ModPatches/Hive Armory</li>
-		<li IfModActive="odz.huscarlpowerarmor">ModPatches/Huscarl - Power Armor</li>
 		<li IfModActive="zal.hyena">ModPatches/Hyena (Continued)</li>
 		<li IfModActive="Ayameduki.HARIdhale">ModPatches/Idhale Race</li>
 		<li IfModActive="detvisor.impactweaponry">ModPatches/Impact Weaponry</li>
@@ -248,7 +242,6 @@
 		<li IfModActive="jemlpro.Infusion2Expansion">ModPatches/Infused 2 Expansion</li>
 		<li IfModActive="latta.infusion">ModPatches/Infusion 2</li>
 		<li IfModActive="SirMashedPotato.InsectsHaveChitin">ModPatches/Insects have chitin</li>
-		<li IfModActive="lts.I">ModPatches/Integrated Implants</li>
 		<li IfModActive="EL.IonWeaponry">ModPatches/Ion Weaponry</li>
 		<li IfModActive="JangoDsoul.CastleWalls,gideon.castlewalls">ModPatches/JDS Castle Walls</li>
 		<li IfModActive="JangoDsoul.EFT.Apparel">ModPatches/JDS EFT Apparel</li>
@@ -316,7 +309,6 @@
 		<li IfModActive="Mlie.MedicalSupplements">ModPatches/Medicine Supplements (Continued)</li>
 		<li IfModActive="JoeDaly.MedMeds.MO">ModPatches/Medieval Medicines 1.4 Medieval Overhaul Edition</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul">ModPatches/Medieval Overhaul</li>
-		<li IfModActive="Turkler.MedievalOverhaul.ArcaneArchaeologists">ModPatches/Medieval Overhaul Arcane Archaeologists</li>
 		<li IfModActive="pphhyy.BarbariansMOSubmod">ModPatches/Medieval Overhaul Barbarians</li>
 		<li IfModActive="DankPyon.Medieval.Overhaul.House.Roxmont">ModPatches/Medieval Overhaul House Roxmont</li>
 		<li IfModActive="Arisher.Medieval.Tailor">ModPatches/Medieval Tailor</li>
@@ -350,6 +342,7 @@
 		<li IfModActive="SirMashedPotato.MorrowRim.AshSwamp">ModPatches/MorrowRim - Ashlands Swamp</li>
 		<li IfModActive="SirMashedPotato.MorrowRim.Bloodmoon">ModPatches/MorrowRim - Bloodmoon</li>
 		<li IfModActive="SirMashedPotato.MorrowRim.ColovianFurHelm">ModPatches/MorrowRim - Colovian Fur Helm</li>
+		<li IfModActive="Nemonian.MY2.Beta">ModPatches/Moyo 2</li>
 		<li IfModActive="Nemonian.MYCartel">ModPatches/Moyo Cartel</li>
 		<li IfModActive="Nemonian.MY">ModPatches/Moyo from the depth</li>
 		<li IfModActive="AOBA.RedMoyo">ModPatches/Moyo light in the abyss</li>
@@ -365,6 +358,9 @@
 		<li IfModActive="neronix17.fr.content.dni">ModPatches/O21 Dragons Not Included</li>
 		<li IfModActive="neronix17.fr.compilation">ModPatches/O21 Forgotten Realms</li>
 		<li IfModActive="neronix17.mechadroids">ModPatches/O21 Mechadroids</li>
+		<li IfModActive="Neronix17.Outland.Core">ModPatches/O21 Outland - Core</li>
+		<li IfModActive="Neronix17.Outland.EastbornEmpire">ModPatches/O21 Outland - Eastborn</li>
+		<li IfModActive="Neronix17.Outland.MotzCoalition">ModPatches/O21 Outland - Motz Coalition</li>
 		<li IfModActive="Odz.WWII.Stalingrad.Uniforms">ModPatches/ODZ Stalingrad - Uniforms</li>
 		<li IfModActive="1.3.Odz.Suits">ModPatches/ODZ Suits</li>
 		<li IfModActive="ObsidiaExpansion.Xenos.Mothoids">ModPatches/Obsidia Expansion</li>
@@ -384,17 +380,14 @@
 		<li IfModActive="Mlie.OuterRimTatooine">ModPatches/Outer Rim - Tatooine</li>
 		<li IfModActive="Mlie.OuterRimTatooineSandcrawler">ModPatches/Outer Rim - Tatooine Sandcrawler</li>
 		<li IfModActive="Neronix17.Outland.Core">ModPatches/Outland - Core</li>
-		<li IfModActive="Neronix17.Outland.EastbornEmpire">ModPatches/Outland - Eastborn</li>
-		<li IfModActive="Neronix17.Outland.Genetics">ModPatches/Outland - Genetics</li>
-		<li IfModActive="Neronix17.Outland.MotzCoalition">ModPatches/Outland - Motz Coalition</li>		
 		<li IfModActive="Neronix17.Outland.RedburnPact">ModPatches/Outland - Redburn Pact</li>
 		<li IfModActive="riprusse.rfPalmCats">ModPatches/Palm Cats</li>
 		<li IfModActive="AhnDemi.PanieltheAutomata">ModPatches/Paniel the Automata</li>
 		<li IfModActive="shauaputa.pawnboldrace">ModPatches/Pawnbold Race</li>
 		<li IfModActive="Mlie.CutePenguin">ModPatches/Penguin</li>
 		<li IfModActive="Sov.WarcasketWeapons">ModPatches/Persona Warcasket Weapons</li>
-		<li IfModActive="Vanya.Polarisbloc.CoreLab,Vanya.Polarisbloc.CoreLab.tmp">ModPatches/Polarisbloc Core Lab</li>
-		<li IfModActive="Vanya.Polarisbloc.SecurityForce,Vanya.Polarisbloc.SecurityForce.tmp">ModPatches/Polarisbloc Security Force</li>
+		<li IfModActive="Vanya.Polarisbloc.CoreLab">ModPatches/Polarisbloc Core Lab</li>
+		<li IfModActive="Vanya.Polarisbloc.SecurityForce">ModPatches/Polarisbloc Security Force</li>
 		<li IfModActive="milk.poleepkwaupdate, GHOST.Poleepkwa">ModPatches/Poleepkwa Race</li>
 		<li IfModActive="BotchJob.PossessedWeapons">ModPatches/Possessed Weapons</li>
 		<li IfModActive="JangoDsoul.T45b.PowerArmor">ModPatches/PowerArmour T-45b</li>
@@ -424,7 +417,6 @@
 		<li IfModActive="CP.RimmuNation.2.Clothing">ModPatches/RH2 Rimmu-Nation² - Clothing</li>
 		<li IfModActive="CP.RimmuNation.2.Security">ModPatches/RH2 Rimmu-Nation² - Security</li>
 		<li IfModActive="CP.RimmuNation.2.Weapons">ModPatches/RH2 Rimmu-Nation² - Weapons</li>
-		<li IfModActive="MrSamuelStreamer.RPGAdventureFlavour">ModPatches/RPG Adventure Flavour Pack</li>
 		<li IfModActive="DanDMan.RSPABSWGASE">ModPatches/RW Pilas and Bows</li>
 		<li IfModActive="ravvy.DD.Void.Addon">ModPatches/RWY Dragon's Descent Void Dwellers</li>
 		<li IfModActive="RunneLatki.RabbieRaceMod">ModPatches/Rabbie The Moonrabbit</li>
@@ -435,13 +427,11 @@
 		<li IfModActive="jkviolet.rakkleracemode">ModPatches/Rakkle the Rattlesnake</li>
 		<li IfModActive="Mlie.RamboWeaponsPack">ModPatches/Rambo Weapons Pack</li>
 		<li IfModActive="Rin.RatkinApparel">ModPatches/Ratkin Apparel+</li>
-		<li IfModActive="SG.Ratkin">ModPatches/Ratkin Xenotype</li>
 		<li IfModActive="JangoDsoul.Ratnik3">ModPatches/Ratnik-3 Prototype Armor</li>
 		<li IfModActive="ReBuild.COTR.DoorsAndCorners">ModPatches/ReBuild - Doors and Corners</li>
 		<li IfModActive="ReGrowth.BOTR.Core">ModPatches/ReGrowth - Core</li>
 		<li IfModActive="ReGrowth.BOTR.ExtinctAnimalsPack">ModPatches/ReGrowth - Extinct Animals</li>
 		<li IfModActive="ReGrowth.BOTR.Wastelands">ModPatches/ReGrowth - Wastelands</li>
-		<li IfModActive="mlie.reinforcedmechanoid2">ModPatches/Reinforced Mechanoid 2</li>
 		<li IfModActive="Bonible.ReconMech">ModPatches/Recon Mechanoid</li>
 		<li IfModActive="Mlie.RedArmy">ModPatches/Red Army</li>
 		<li IfModActive="vonschtirlitz.RCA">ModPatches/Redcoat Apparel</li>
@@ -495,7 +485,6 @@
 		<li IfModActive="rimsenal.feral">ModPatches/Rimsenal Feral</li>
 		<li IfModActive="rimsenal.security">ModPatches/Rimsenal Security</li>
 		<li IfModActive="Rimsenal.Askbarn">ModPatches/Rimsenal Xenotype Pack - Askbarn</li>
-		<li IfModActive="Rimsenal.Harana">ModPatches/Rimsenal Xenotype Pack - Harana</li>
 		<li IfModActive="SirMashedPotato.DarkDescent">ModPatches/Rimworld - The Dark Descent</li>
 		<li IfModActive="Mlie.RRUESContactLightArmory">ModPatches/Risk of Rain UES Contact Light Armory</li>
 		<li IfModActive="Ghastly.RoboticServitude">ModPatches/Robotic Servitude</li>
@@ -531,7 +520,6 @@
 		<li IfModActive="Koni.Misc.SteamworldUniforms">ModPatches/Steamworld Uniforms</li>
 		<li IfModActive="Scurvyez.Bastyon">ModPatches/Steves Animals</li>
 		<li IfModActive="det.sbdelights">ModPatches/Stoneborn - Delights</li>
-		<li IfModActive="Artemiish.SupernaturalWeapons">ModPatches/Supernatural Weapons</li>
 		<li IfModActive="Mlie.Swords">ModPatches/Swords</li>
 		<li IfModActive="Trickity.Conversion.Staff">ModPatches/T's Conversion Staff</li>
 		<li IfModActive="Trickity.Samurai.Faction">ModPatches/T's Samurai Faction</li>
@@ -549,7 +537,6 @@
 		<li IfModActive="syrchalis.thrumkin">ModPatches/Thrumkin</li>
 		<li IfModActive="JAHV.SpacerVehiclesHAL.CONTINUED">Modpatches/Titan Vehicles</li>
 		<li IfModActive="Mlie.ToolmetricsRedux">ModPatches/Toolmetrics Redux</li>
-		<li IfModActive="TheSimpleDude42.ToolsOPlenty">ModPatches/Tools O'Plenty</li>
 		<li IfModActive="RicoFox233.TouhouStyle.ScarletDevil">ModPatches/TouhouStyle</li>
 		<li IfModActive="Gunmar.TribalWarriorSet">ModPatches/Tribal Warrior Set</li>
 		<li IfModActive="ALIEN.TsarArmory">ModPatches/Tsar Armory</li>
@@ -583,10 +570,11 @@
 		<li IfModActive="OskarPotocki.VFE.Empire">ModPatches/Vanilla Factions Expanded - Empire</li>
 		<li IfModActive="OskarPotocki.VFE.Insectoid2">ModPatches/Vanilla Factions Expanded - Insectoids 2</li>
 		<li IfModActive="OskarPotocki.VFE.Mechanoid">ModPatches/Vanilla Factions Expanded - Mechanoids</li>
-		<li IfModActive="OskarPotocki.VFE.Medieval2">ModPatches/Vanilla Factions Expanded - Medieval 2</li>
+		<li IfModActive="OskarPotocki.VanillaFactionsExpanded.MedievalModule">ModPatches/Vanilla Factions Expanded - Medieval</li>
 		<li IfModActive="OskarPotocki.VFE.Pirates">ModPatches/Vanilla Factions Expanded - Pirates</li>
 		<li IfModActive="OskarPotocki.VanillaFactionsExpanded.SettlersModule">ModPatches/Vanilla Factions Expanded - Settlers</li>
 		<li IfModActive="OskarPotocki.VFE.Tribals">ModPatches/Vanilla Factions Expanded - Tribals</li>
+		<li IfModActive="OskarPotocki.VFE.Vikings">ModPatches/Vanilla Factions Expanded - Vikings</li>
 		<li IfModActive="VanillaExpanded.VFESecurity">ModPatches/Vanilla Furniture Expanded - Security</li>
 		<li IfModActive="VanillaExpanded.VGeneticsE">ModPatches/Vanilla Genetics Expanded</li>
 		<li IfModActive="VanillaExpanded.Ideo.Dryads">ModPatches/Vanilla Ideology Expanded - Dryads</li>
@@ -594,7 +582,6 @@
 		<li IfModActive="VanillaExpanded.VMemesE">ModPatches/Vanilla Ideology Expanded - Memes and Structures</li>
 		<li IfModActive="VanillaExpanded.VPersonaWeaponsE">ModPatches/Vanilla Persona Weapons Expanded</li>
 		<li IfModActive="VanillaExpanded.VPlantsEMushrooms">ModPatches/Vanilla Plants Expanded - Mushrooms</li>
-		<li IfModActive="PrestigeSpecialistArmours.Final">ModPatches/Vanilla Prestige Specialist Armours Reworked</li>
 		<li IfModActive="VanillaExpanded.VPsycastsE">ModPatches/Vanilla Psycasts Expanded</li>
 		<li IfModActive="VanillaExpanded.VPE.Hemosage">ModPatches/Vanilla Psycasts Expanded - Hemosage</li>
 		<li IfModActive="Chairheir.VPERunesmith">ModPatches/Vanilla Psycasts Expanded - Runesmith</li>
@@ -632,7 +619,6 @@
 		<li IfModActive="flangopink.VanillaXCOMPlasmaWeapons">ModPatches/Vanilla XCOM Plasma Weapons</li>
 		<li IfModActive="flangopink.VanillaXCOMWeapons">ModPatches/Vanilla XCOM Weapons</li>
 		<li IfModActive="KavaCaligula.VFClassicMechs">ModPatches/Vehicle Framework Expanded - Classic Mechs</li>
-		<li IfModActive="Gunmar.VictorianEraApparels">ModPatches/Victorian Era Apparels</li>
 		<li IfModActive="Mlie.VulpineRacePack">ModPatches/Vulpine Pack</li>
 		<li IfModActive="VsEdit.ods.wwiigerman.uniforms">ModPatches/WWII German Uniforms</li>
 		<li IfModActive="TheWingedGuy.WWII.Soviet.Faction">ModPatches/WWII Soviet Faction</li>
@@ -656,6 +642,7 @@
 		<li IfModActive="Ayameduki.HARXenoorca">ModPatches/Xenoorca Race</li>
 		<li IfModActive="MrKociak.YetAnotherProstheticExpansionModCore">ModPatches/YetAnotherProsthetics - Core</li>
 		<li IfModActive="brrainz.zombieland">ModPatches/Zombieland</li>
+		<li IfModActive="BlackMarket420.Kerberos">ModPatches/Kerberos Protect Gears and Firearms</li>
 		<!-- Mod Patches (Assemblies) -->
 		<li IfModActive="rwmt.Multiplayer">ModPatches/Multiplayer</li>
 		<li IfModActive="smashphil.neceros.srtsexpanded">ModPatches/SRTS</li>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -271,8 +271,8 @@
 		<li IfModActive="ALIEN.KaiserArmory">ModPatches/Kaiser Armory</li>
 		<li IfModActive="psyche.kemomimihouse">ModPatches/Kemomimihouse</li>
 		<li IfModActive="Moo.kemomimihouse.Kz">ModPatches/kemomimihouse Kz</li>
-		<li IfModActive="BlackMarket420.Kerberos">ModPatches/Kerberos Protect Gears and Firearms</li>
 		<li IfModActive="Kenshi.Armory.Geminingen, biowreck.KenshiArmory">ModPatches/Kenshi Armory</li>
+		<li IfModActive="BlackMarket420.Kerberos">ModPatches/Kerberos Protect Gears and Firearms</li>
 		<li IfModActive="ssulunge.KijinRace3">ModPatches/Kijin 3.0</li>
 		<li IfModActive="RicoFox233.KLKApparel">ModPatches/Kill la Kill Styles Pack</li>
 		<li IfModActive="JangoDsoul.Bot.Soldier">ModPatches/Killzone Concept Armor Set</li>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <!-- MG-42 -->
-    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+
+	<!-- MG-42 -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_JinRoh_MG</defName>
 		<statBases>
 			<Mass>11.6</Mass>
@@ -15,7 +16,7 @@
 		<costList>
 			<Steel>95</Steel>
 			<ComponentIndustrial>6</ComponentIndustrial>
-            <WoodLog>10</WoodLog>
+			<WoodLog>10</WoodLog>
 		</costList>
 		<Properties>
 			<recoilAmount>1.47</recoilAmount>
@@ -50,7 +51,7 @@
 		</weaponTags>
 	</Operation>
 
-    <!-- MG-34 -->
+	<!-- MG-34 -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_PanzerJager_MG</defName>
 		<statBases>
@@ -65,7 +66,7 @@
 		<costList>
 			<Steel>95</Steel>
 			<ComponentIndustrial>5</ComponentIndustrial>
-            <WoodLog>10</WoodLog>
+			<WoodLog>10</WoodLog>
 		</costList>
 		<Properties>
 			<recoilAmount>1.20</recoilAmount>
@@ -100,12 +101,12 @@
 		</weaponTags>
 	</Operation>
 
-    <!-- == Shared patches for firearm melee tools == -->
-
+	<!-- == Shared patches for firearm melee tools == -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
 			defName="Gun_PanzerJager_MG" or
-			defName="Gun_JinRoh_MG"]/tools </xpath>
+			defName="Gun_JinRoh_MG"]/tools
+		</xpath>
 		<value>
 			<tools>
 				<li Class="CombatExtended.ToolCE">
@@ -142,4 +143,5 @@
 			</tools>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- MG-42 -->
+    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_JinRoh_MG</defName>
+		<statBases>
+			<Mass>11.6</Mass>
+			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.06</ShotSpread>
+			<SwayFactor>1.67</SwayFactor>
+			<Bulk>15.20</Bulk>
+			<WorkToMake>38000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>95</Steel>
+			<ComponentIndustrial>6</ComponentIndustrial>
+            <WoodLog>10</WoodLog>
+		</costList>
+		<Properties>
+			<recoilAmount>1.47</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_792x57mmMauser_FMJ</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>62</range>
+			<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
+			<burstShotCount>12</burstShotCount>
+			<soundCast>Shot_MachineGun</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>250</magazineSize>
+			<reloadTime>7.8</reloadTime>
+			<ammoSet>AmmoSet_792x57mmMauser</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>8</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_MachineGun</li>
+			<li>Bipod_LMG</li>
+		</weaponTags>
+	</Operation>
+
+    <!-- MG-34 -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_PanzerJager_MG</defName>
+		<statBases>
+			<Mass>12.1</Mass>
+			<RangedWeapon_Cooldown>0.56</RangedWeapon_Cooldown>
+			<SightsEfficiency>1</SightsEfficiency>
+			<ShotSpread>0.04</ShotSpread>
+			<SwayFactor>1.7</SwayFactor>
+			<Bulk>14.19</Bulk>
+			<WorkToMake>60000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>95</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
+            <WoodLog>10</WoodLog>
+		</costList>
+		<Properties>
+			<recoilAmount>1.20</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_792x57mmMauser_FMJ</defaultProjectile>
+			<warmupTime>1.3</warmupTime>
+			<range>62</range>
+			<ticksBetweenBurstShots>4</ticksBetweenBurstShots>
+			<burstShotCount>12</burstShotCount>
+			<soundCast>Shot_MachineGun</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+			<recoilPattern>Mounted</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>50</magazineSize>
+			<reloadTime>7</reloadTime>
+			<ammoSet>AmmoSet_792x57mmMauser</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>6</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>CE_MachineGun</li>
+			<li>Bipod_LMG</li>
+		</weaponTags>
+	</Operation>
+
+    <!-- == Shared patches for firearm melee tools == -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName="Gun_PanzerJager_MG" or
+			defName="Gun_JinRoh_MG"]/tools </xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
@@ -3,9 +3,7 @@
 
 	<!-- == Shared patches for firearm melee tools == -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[
-			defName="Gun_PanzerJager_MG" or
-			defName="Gun_JinRoh_MG"]/tools
+		<xpath>Defs/ThingDef[defName="Gun_PanzerJager_MG" or defName="Gun_JinRoh_MG"]/tools
 		</xpath>
 		<value>
 			<tools>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Heavy.xml
@@ -1,6 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
+	<!-- == Shared patches for firearm melee tools == -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[
+			defName="Gun_PanzerJager_MG" or
+			defName="Gun_JinRoh_MG"]/tools
+		</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
 	<!-- MG-42 -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_JinRoh_MG</defName>
@@ -99,49 +142,6 @@
 			<li>CE_MachineGun</li>
 			<li>Bipod_LMG</li>
 		</weaponTags>
-	</Operation>
-
-	<!-- == Shared patches for firearm melee tools == -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[
-			defName="Gun_PanzerJager_MG" or
-			defName="Gun_JinRoh_MG"]/tools
-		</xpath>
-		<value>
-			<tools>
-				<li Class="CombatExtended.ToolCE">
-					<label>stock</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<chanceFactor>1.5</chanceFactor>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>barrel</label>
-					<capacities>
-						<li>Blunt</li>
-					</capacities>
-					<power>5</power>
-					<cooldownTime>2.02</cooldownTime>
-					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
-				</li>
-				<li Class="CombatExtended.ToolCE">
-					<label>muzzle</label>
-					<capacities>
-						<li>Poke</li>
-					</capacities>
-					<power>8</power>
-					<cooldownTime>1.55</cooldownTime>
-					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
-					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-				</li>
-			</tools>
-		</value>
 	</Operation>
 
 </Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
@@ -180,7 +180,6 @@
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 			<aiAimMode>SuppressFire</aiAimMode>
 		</FireModes>
-		<!-- No additional CE weaponTags needed -->
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Mauser C96 -->
+    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>Gun_Mauser</defName>
+		<statBases>
+			<Mass>1.13</Mass>
+			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.70</SightsEfficiency>
+			<ShotSpread>0.12</ShotSpread>
+			<SwayFactor>1.42</SwayFactor>
+			<Bulk>3.12</Bulk>
+			<WorkToMake>6000</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>30</Steel>
+			<ComponentIndustrial>2</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_763x25mmMauser_FMJ</defaultProjectile>
+			<warmupTime>0.6</warmupTime>
+			<range>12</range>
+			<soundCast>Shot_Mauser</soundCast>
+			<soundCastTail>GunTail_Light</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<targetParams>
+				<canTargetLocations>false</canTargetLocations>
+			</targetParams>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>10</magazineSize>
+			<reloadTime>4.3</reloadTime>
+			<ammoSet>AmmoSet_763x25mmMauser</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aimedBurstShotCount>0</aimedBurstShotCount>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+            <aiAimMode>Snapshot</aiAimMode>
+		</FireModes>
+		<weaponTags>
+			<li>SimpleGun</li>
+            <li>CE_Sidearm</li>
+            <li>CE_AI_BROOM</li>
+            <li>CE_OneHandedWeapon</li>
+		</weaponTags>
+        <weaponClasses>
+            <li>RangedLight</li>
+        </weaponClasses>
+        <tools>
+            <li Class="CombatExtended.ToolCE">
+                <label>grip</label>
+                <capacities>
+                    <li>Blunt</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>1.54</cooldownTime>
+                <chanceFactor>1.5</chanceFactor>
+                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+            </li>
+            <li Class="CombatExtended.ToolCE">
+                <label>muzzle</label>
+                <capacities>
+                    <li>Poke</li>
+                </capacities>
+                <power>2</power>
+                <cooldownTime>1.54</cooldownTime>
+                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+            </li>
+        </tools>
+    </Operation>
+
+    <!-- STG 44 -->
+    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_STG_Rifle</defName>
+		<statBases>
+			<Mass>4.6</Mass>
+			<RangedWeapon_Cooldown>0.36</RangedWeapon_Cooldown>
+			<SightsEfficiency>1.00</SightsEfficiency>
+			<ShotSpread>0.08</ShotSpread>
+			<SwayFactor>1.40</SwayFactor>
+			<Bulk>9.40</Bulk>
+			<WorkToMake>28500</WorkToMake>
+		</statBases>
+		<costList>
+			<WoodLog>5</WoodLog>
+			<Steel>60</Steel>
+			<ComponentIndustrial>5</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<recoilAmount>1.54</recoilAmount>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_792x33mmKurz_FMJ</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>48</range>
+			<burstShotCount>6</burstShotCount>
+			<ticksBetweenBurstShots>7</ticksBetweenBurstShots>
+			<soundCast>Shot_STG44</soundCast>
+			<soundCastTail>GunTail_Medium</soundCastTail>
+			<muzzleFlashScale>9</muzzleFlashScale>
+			<recoilPattern>Regular</recoilPattern>
+		</Properties>
+		<AmmoUser>
+			<magazineSize>30</magazineSize>
+			<reloadTime>4</reloadTime>
+			<ammoSet>AmmoSet_792x33mmKurz</ammoSet>
+		</AmmoUser>
+		<FireModes>
+			<aiUseBurstMode>TRUE</aiUseBurstMode>
+			<aiAimMode>AimedShot</aiAimMode>
+			<aimedBurstShotCount>3</aimedBurstShotCount>
+		</FireModes>
+		<weaponTags>
+			<li>CE_AI_Rifle</li>
+		</weaponTags>
+    </Operation>
+
+    <!-- Grenade Launcher Pistol -->
+    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+        <defName>Gun_GrenadePistol</defName>
+        <statBases>
+			<Mass>2.60</Mass>
+			<RangedWeapon_Cooldown>0.50</RangedWeapon_Cooldown>
+			<SightsEfficiency>0.70</SightsEfficiency>
+			<ShotSpread>0.17</ShotSpread>
+			<SwayFactor>3.14</SwayFactor>
+			<Bulk>6.83</Bulk>
+			<WorkToMake>11500</WorkToMake>
+		</statBases>
+		<costList>
+			<Steel>45</Steel>
+			<ComponentIndustrial>2</ComponentIndustrial>
+		</costList>
+		<Properties>
+			<verbClass>CombatExtended.Verb_ShootCE</verbClass>
+			<hasStandardCommand>true</hasStandardCommand>
+			<defaultProjectile>Bullet_40x46mmGrenade_HE</defaultProjectile>
+			<warmupTime>1.1</warmupTime>
+			<range>44</range>
+			<minRange>5</minRange>
+			<soundCast>Shot_GrenadePistol</soundCast>
+			<soundCastTail>GunTail_Heavy</soundCastTail>
+			<onlyManualCast>true</onlyManualCast>
+			<stopBurstWithoutLos>false</stopBurstWithoutLos>
+			<muzzleFlashScale>14</muzzleFlashScale>
+			<targetParams>
+				<canTargetLocations>true</canTargetLocations>
+			</targetParams>
+		</Properties>
+
+		<AmmoUser>
+			<magazineSize>1</magazineSize>
+			<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
+			<reloadTime>0.85</reloadTime>
+			<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
+		</AmmoUser>
+
+		<FireModes>
+			<aiUseBurstMode>FALSE</aiUseBurstMode>
+			<aiAimMode>SuppressFire</aiAimMode>
+		</FireModes>
+
+		<!-- No additional CE weaponTags needed -->
+
+		<AllowWithRunAndGun>false</AllowWithRunAndGun>
+    </Operation>
+</Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
@@ -1,6 +1,47 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
+	<!-- == Shared patches for firearm melee tools == -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Gun_Mauser"]/tools
+		</xpath>
+		<value>
+			<tools>
+				<li Class="CombatExtended.ToolCE">
+					<label>stock</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<chanceFactor>1.5</chanceFactor>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>barrel</label>
+					<capacities>
+						<li>Blunt</li>
+					</capacities>
+					<power>5</power>
+					<cooldownTime>2.02</cooldownTime>
+					<armorPenetrationBlunt>1.630</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Barrel</linkedBodyPartsGroup>
+				</li>
+				<li Class="CombatExtended.ToolCE">
+					<label>muzzle</label>
+					<capacities>
+						<li>Poke</li>
+					</capacities>
+					<power>8</power>
+					<cooldownTime>1.55</cooldownTime>
+					<armorPenetrationBlunt>2.755</armorPenetrationBlunt>
+					<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+				</li>
+			</tools>
+		</value>
+	</Operation>
+
 	<!-- Mauser C96 -->
 	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_Mauser</defName>
@@ -49,29 +90,6 @@
 		<weaponClasses>
 			<li>RangedLight</li>
 		</weaponClasses>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<label>grip</label>
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>2</power>
-				<cooldownTime>1.54</cooldownTime>
-				<chanceFactor>1.5</chanceFactor>
-				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-			</li>
-			<li Class="CombatExtended.ToolCE">
-				<label>muzzle</label>
-				<capacities>
-					<li>Poke</li>
-				</capacities>
-				<power>2</power>
-				<cooldownTime>1.54</cooldownTime>
-				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-			</li>
-		</tools>
 	</Operation>
 
 	<!-- STG 44 -->
@@ -152,14 +170,12 @@
 				<canTargetLocations>true</canTargetLocations>
 			</targetParams>
 		</Properties>
-
 		<AmmoUser>
 			<magazineSize>1</magazineSize>
 			<AmmoGenPerMagOverride>3</AmmoGenPerMagOverride>
 			<reloadTime>0.85</reloadTime>
 			<ammoSet>AmmoSet_40x46mmGrenade</ammoSet>
 		</AmmoUser>
-
 		<FireModes>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 			<aiAimMode>SuppressFire</aiAimMode>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Weapons/Kerb_CE_Standard.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <!-- Mauser C96 -->
-    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-        <defName>Gun_Mauser</defName>
+
+	<!-- Mauser C96 -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_Mauser</defName>
 		<statBases>
 			<Mass>1.13</Mass>
 			<RangedWeapon_Cooldown>0.37</RangedWeapon_Cooldown>
@@ -37,44 +38,44 @@
 		<FireModes>
 			<aimedBurstShotCount>0</aimedBurstShotCount>
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
-            <aiAimMode>Snapshot</aiAimMode>
+			<aiAimMode>Snapshot</aiAimMode>
 		</FireModes>
 		<weaponTags>
 			<li>SimpleGun</li>
-            <li>CE_Sidearm</li>
-            <li>CE_AI_BROOM</li>
-            <li>CE_OneHandedWeapon</li>
+			<li>CE_Sidearm</li>
+			<li>CE_AI_BROOM</li>
+			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
-        <weaponClasses>
-            <li>RangedLight</li>
-        </weaponClasses>
-        <tools>
-            <li Class="CombatExtended.ToolCE">
-                <label>grip</label>
-                <capacities>
-                    <li>Blunt</li>
-                </capacities>
-                <power>2</power>
-                <cooldownTime>1.54</cooldownTime>
-                <chanceFactor>1.5</chanceFactor>
-                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-                <linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
-            </li>
-            <li Class="CombatExtended.ToolCE">
-                <label>muzzle</label>
-                <capacities>
-                    <li>Poke</li>
-                </capacities>
-                <power>2</power>
-                <cooldownTime>1.54</cooldownTime>
-                <armorPenetrationBlunt>0.555</armorPenetrationBlunt>
-                <linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
-            </li>
-        </tools>
-    </Operation>
+		<weaponClasses>
+			<li>RangedLight</li>
+		</weaponClasses>
+		<tools>
+			<li Class="CombatExtended.ToolCE">
+				<label>grip</label>
+				<capacities>
+					<li>Blunt</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<chanceFactor>1.5</chanceFactor>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Grip</linkedBodyPartsGroup>
+			</li>
+			<li Class="CombatExtended.ToolCE">
+				<label>muzzle</label>
+				<capacities>
+					<li>Poke</li>
+				</capacities>
+				<power>2</power>
+				<cooldownTime>1.54</cooldownTime>
+				<armorPenetrationBlunt>0.555</armorPenetrationBlunt>
+				<linkedBodyPartsGroup>Muzzle</linkedBodyPartsGroup>
+			</li>
+		</tools>
+	</Operation>
 
-    <!-- STG 44 -->
-    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+	<!-- STG 44 -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
 		<defName>Gun_STG_Rifle</defName>
 		<statBases>
 			<Mass>4.6</Mass>
@@ -117,12 +118,12 @@
 		<weaponTags>
 			<li>CE_AI_Rifle</li>
 		</weaponTags>
-    </Operation>
+	</Operation>
 
-    <!-- Grenade Launcher Pistol -->
-    <Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
-        <defName>Gun_GrenadePistol</defName>
-        <statBases>
+	<!-- Grenade Launcher Pistol -->
+	<Operation Class="CombatExtended.PatchOperationMakeGunCECompatible">
+		<defName>Gun_GrenadePistol</defName>
+		<statBases>
 			<Mass>2.60</Mass>
 			<RangedWeapon_Cooldown>0.50</RangedWeapon_Cooldown>
 			<SightsEfficiency>0.70</SightsEfficiency>
@@ -163,9 +164,8 @@
 			<aiUseBurstMode>FALSE</aiUseBurstMode>
 			<aiAimMode>SuppressFire</aiAimMode>
 		</FireModes>
-
 		<!-- No additional CE weaponTags needed -->
-
 		<AllowWithRunAndGun>false</AllowWithRunAndGun>
-    </Operation>
+	</Operation>
+
 </Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
@@ -4,7 +4,7 @@
 	<!-- =============================== HELMET =============================================================================-->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/equippedStatOffsets </xpath>
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
 		<value>
 			<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
 			<SmokeSensitivity>-1</SmokeSensitivity>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- =============================== HELMET =============================================================================-->
+	<!-- ===== HELMET ===== -->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
@@ -47,10 +47,12 @@
 
 	<!-- Layers -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/apparel/layers</xpath>
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/apparel</xpath>
 		<value>
-			<li>OnHead</li>
-			<li>StrappedHead</li>
+			<apparel>
+				<li>OnHead</li>
+				<li>StrappedHead</li>
+			</apparel>
 		</value>
 	</Operation>
 
@@ -91,7 +93,7 @@
 		</value>
 	</Operation>
 
-	<!-- =============================== ARMOR =============================================================================-->
+	<!-- ===== ARMOR =====-->
 	<!--Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
@@ -131,15 +133,6 @@
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>32</ArmorRating_Blunt>
-		</value>
-	</Operation>
-
-	<!-- Cover hands and feet -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/apparel/bodyPartGroups</xpath>
-		<value>
-			<li>Hands</li>
-			<li>Feet</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
@@ -12,7 +12,6 @@
 		</value>
 	</Operation>
 
-	<!-- MaxHitPoints -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/MaxHitPoints</xpath>
 		<value>
@@ -20,7 +19,6 @@
 		</value>
 	</Operation>
 
-	<!-- Stat Bases -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases</xpath>
 		<value>
@@ -29,7 +27,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -37,7 +34,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -45,18 +41,16 @@
 		</value>
 	</Operation>
 
-	<!-- Layers -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/apparel</xpath>
 		<value>
-			<apparel>
+			<layers>
 				<li>OnHead</li>
 				<li>StrappedHead</li>
-			</apparel>
+			</layers>
 		</value>
 	</Operation>
 
-	<!-- Face Stuff -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]</xpath>
 		<value>
@@ -94,7 +88,7 @@
 	</Operation>
 
 	<!-- ===== ARMOR =====-->
-	<!--Equipped Stat Offsets -->
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
 		<value>
@@ -103,24 +97,15 @@
 		</value>
 	</Operation>
 
-	<!-- Max Hit Points -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/MaxHitPoints</xpath>
 		<value>
 			<MaxHitPoints>450</MaxHitPoints>
-		</value>
-	</Operation>
-
-	<!-- Stat Bases -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases</xpath>
-		<value>
 			<Bulk>20</Bulk>
-			<WornBulk>8</WornBulk>
+			<WornBulk>8</WornBulk>	
 		</value>
 	</Operation>
 
-	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -128,7 +113,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -136,7 +120,6 @@
 		</value>
 	</Operation>
 
-	<!-- Partial covers -->
 	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]</xpath>
 		<value>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Armor_Patches.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- =============================== HELMET =============================================================================-->
+	<!-- Equipped Stat Offsets -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/equippedStatOffsets </xpath>
+		<value>
+			<ShootingAccuracyPawn>0.10</ShootingAccuracyPawn>
+			<SmokeSensitivity>-1</SmokeSensitivity>
+			<NightVisionEfficiency_Apparel>0.5</NightVisionEfficiency_Apparel>
+		</value>
+	</Operation>
+
+	<!-- MaxHitPoints -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>200</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<!-- Stat Bases -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases</xpath>
+		<value>
+			<Bulk>2</Bulk>
+			<WornBulk>1</WornBulk>
+		</value>
+	</Operation>
+
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>16</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>30</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Layers -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]/apparel/layers</xpath>
+		<value>
+			<li>OnHead</li>
+			<li>StrappedHead</li>
+		</value>
+	</Operation>
+
+	<!-- Face Stuff -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="HelmetMachineableBase_ProtectGears"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.70</ArmorRating_Sharp>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.70</ArmorRating_Blunt>
+						<parts>
+							<li>Eye</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.50</ArmorRating_Sharp>
+						<parts>
+							<li>Nose</li>
+							<li>Jaw</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.50</ArmorRating_Blunt>
+						<parts>
+							<li>Nose</li>
+							<li>Jaw</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+	<!-- =============================== ARMOR =============================================================================-->
+	<!--Equipped Stat Offsets -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryWeight>100</CarryWeight>
+			<CarryBulk>20</CarryBulk>
+		</value>
+	</Operation>
+
+	<!-- Max Hit Points -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/MaxHitPoints</xpath>
+		<value>
+			<MaxHitPoints>450</MaxHitPoints>
+		</value>
+	</Operation>
+
+	<!-- Stat Bases -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases</xpath>
+		<value>
+			<Bulk>20</Bulk>
+			<WornBulk>8</WornBulk>
+		</value>
+	</Operation>
+
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>18</ArmorRating_Sharp>
+		</value>
+	</Operation>
+
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>32</ArmorRating_Blunt>
+		</value>
+	</Operation>
+
+	<!-- Cover hands and feet -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]/apparel/bodyPartGroups</xpath>
+		<value>
+			<li>Hands</li>
+			<li>Feet</li>
+		</value>
+	</Operation>
+
+	<!-- Partial covers -->
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[@Name="ArmorMachineableBase_ProtectGears"]</xpath>
+		<value>
+			<li Class="CombatExtended.PartialArmorExt">
+				<stats>
+					<li>
+						<ArmorRating_Sharp>0.60</ArmorRating_Sharp>
+						<parts>
+							<li>Neck</li>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.60</ArmorRating_Blunt>
+						<parts>
+							<li>Neck</li>
+							<li>Hand</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.90</ArmorRating_Sharp>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.90</ArmorRating_Blunt>
+						<parts>
+							<li>Leg</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Sharp>0.80</ArmorRating_Sharp>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+					<li>
+						<ArmorRating_Blunt>0.80</ArmorRating_Blunt>
+						<parts>
+							<li>Arm</li>
+						</parts>
+					</li>
+				</stats>
+			</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
@@ -1,13 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- =============================== PACKS =============================================================================-->
-	<!-- RemoveCarryCapacity -->
-	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity</xpath>
-	</Operation>
+	<!-- PACKS -->
 
-	<!-- Base Bulk -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/statBases</xpath>
 		<value>
@@ -15,9 +10,8 @@
 		</value>
 	</Operation>
 
-	<!-- Carry Bulk -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity</xpath>
 		<value>
 			<CarryingCapacity>100</CarryingCapacity>
 			<CarryBulk>100</CarryBulk>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
@@ -13,8 +13,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity</xpath>
 		<value>
-			<CarryingCapacity>100</CarryingCapacity>
-			<CarryBulk>100</CarryBulk>
+			<CarryBulk>60</CarryBulk>
 		</value>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <!-- =============================== PACKS =============================================================================-->
+
+	<!-- =============================== PACKS =============================================================================-->
 	<!-- RemoveCarryCapacity -->
 	<Operation Class="PatchOperationRemove">
-		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity </xpath>
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity</xpath>
 	</Operation>
+
 	<!-- Base Bulk -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/statBases </xpath>
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/statBases</xpath>
 		<value>
 			<Bulk>20</Bulk>
 		</value>
 	</Operation>
+
 	<!-- Carry Bulk -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
@@ -20,4 +23,5 @@
 			<CarryBulk>100</CarryBulk>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Packs_Patches.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- =============================== PACKS =============================================================================-->
+	<!-- RemoveCarryCapacity -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets/CarryingCapacity </xpath>
+	</Operation>
+	<!-- Base Bulk -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/statBases </xpath>
+		<value>
+			<Bulk>20</Bulk>
+		</value>
+	</Operation>
+	<!-- Carry Bulk -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="AmmoPackMachineableBase_ProtectGears"]/equippedStatOffsets</xpath>
+		<value>
+			<CarryingCapacity>100</CarryingCapacity>
+			<CarryBulk>100</CarryBulk>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- =============================== Wrist Shield =============================================================================-->
+	<!-- Equipped Stat Offsets -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/equippedStatOffsets</xpath>
+		<value>
+			<ReloadSpeed>-0.05</ReloadSpeed>
+			<MeleeHitChance>0</MeleeHitChance>
+			<ShootingAccuracyPawn>-0.1</ShootingAccuracyPawn>
+			<AimingAccuracy>-0.05</AimingAccuracy>
+			<Suppressability>-0.25</Suppressability>
+			<MeleeCritChance>-0.05</MeleeCritChance>
+			<MeleeParryChance>0.75</MeleeParryChance>
+		</value>
+	</Operation>
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>10</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	<!-- Stat Bases -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+			<Mass>5</Mass>
+			<Bulk>3.5</Bulk>
+			<WornBulk>2</WornBulk>
+		</value>
+	</Operation>
+	<!-- Layers -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/apparel/layers</xpath>
+		<value>
+			<li>Shield</li>
+		</value>
+	</Operation>
+	<!-- =============================== Combat Shield =============================================================================-->
+	<!-- Equipped Stat Offsets -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/equippedStatOffsets</xpath>
+		<value>
+			<ReloadSpeed>-0.05</ReloadSpeed>
+			<MeleeHitChance>-1</MeleeHitChance>
+			<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+			<AimingAccuracy>-0.15</AimingAccuracy>
+			<Suppressability>-0.45</Suppressability>
+			<MeleeCritChance>-0.2</MeleeCritChance>
+			<MeleeParryChance>1.0</MeleeParryChance>
+		</value>
+	</Operation>
+	<!-- Stat Bases -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			<Mass>9</Mass>
+			<Bulk>10</Bulk>
+			<WornBulk>7</WornBulk>
+		</value>
+	</Operation>
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>22</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	<!-- Layers -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/apparel/layers</xpath>
+		<value>
+			<li>Shield</li>
+		</value>
+	</Operation>
+
+	<!-- =============================== Tower Shield =============================================================================-->
+	<!-- Equipped Stat Offsets -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/equippedStatOffsets</xpath>
+		<value>
+			<ReloadSpeed>-0.3</ReloadSpeed>
+			<MeleeHitChance>-4</MeleeHitChance>
+			<ShootingAccuracyPawn>-0.4</ShootingAccuracyPawn>
+			<AimingAccuracy>-0.2</AimingAccuracy>
+			<Suppressability>-0.5</Suppressability>
+			<MeleeCritChance>-0.2</MeleeCritChance>
+			<MeleeParryChance>1.0</MeleeParryChance>
+		</value>
+	</Operation>
+	<!-- Stat Bases -->
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases</xpath>
+		<value>
+			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			<Mass>18</Mass>
+			<Bulk>17</Bulk>
+			<WornBulk>12</WornBulk>
+		</value>
+	</Operation>
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
+		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+		</value>
+	</Operation>
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>26</ArmorRating_Blunt>
+		</value>
+	</Operation>
+	<!-- Layers -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/apparel/layers</xpath>
+		<value>
+			<li>Shield</li>
+		</value>
+	</Operation>
+</Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -2,23 +2,21 @@
 <Patch>
 
 	<!-- ===== Wrist Shield ===== -->
-	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]</xpath>
 		<value>
 			<equippedStatOffsets>
 				<ReloadSpeed>-0.05</ReloadSpeed>
-				<MeleeHitChance>0</MeleeHitChance>
-				<ShootingAccuracyPawn>-0.1</ShootingAccuracyPawn>
-				<AimingAccuracy>-0.05</AimingAccuracy>
-				<Suppressability>-0.25</Suppressability>
-				<MeleeCritChance>-0.05</MeleeCritChance>
-				<MeleeParryChance>0.75</MeleeParryChance>
+				<ShootingAccuracyPawn>-0.25</ShootingAccuracyPawn>
+				<AimingAccuracy>-0.15</AimingAccuracy>
+				<Suppressability>-0.4</Suppressability>
+				<MeleeHitChance>-0.7</MeleeHitChance>				
+				<MeleeCritChance>-0.2</MeleeCritChance>
+				<MeleeParryChance>1.0</MeleeParryChance>
 			</equippedStatOffsets>
 		</value>
 	</Operation>
 
-	<!-- Mass & Bulk -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/Mass</xpath>
 		<value>
@@ -31,15 +29,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>10</ArmorRating_Sharp>
-			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>4</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -54,6 +51,12 @@
 	</Operation>
 
 	<!-- ===== Combat Shield ===== -->
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>ShieldBase</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/equippedStatOffsets</xpath>
@@ -80,28 +83,74 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>12</ArmorRating_Sharp>
-			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>22</ArmorRating_Blunt>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/apparel/layers</xpath>
-			<value>	
-				<layers>
-					<li>Shield</li>
-				</layers>
-			</value>
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/apparel/drawData</xpath>
+		<value>
+			<renderNodeProperties>
+				<li>
+					<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+					<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+					<texPath>Things/Apparels/RiotShield/KerberosRiotShield</texPath>
+					<shaderTypeDef>CutoutComplex</shaderTypeDef>
+					<parentTagDef>ApparelBody</parentTagDef>
+					<drawData>
+						<scale>0.8</scale>
+						<defaultData>
+							<layer>80</layer>
+						</defaultData>
+						<dataEast>
+							<layer>-5</layer>
+							<offset>(0, 0, -0.1)</offset>
+							<rotationOffset>30</rotationOffset>
+						</dataEast>
+						<dataWest>
+							<rotationOffset>-30</rotationOffset>
+						</dataWest>
+						<dataNorth>
+							<layer>-5</layer>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataNorth>
+						<dataSouth>
+							<offset>(0.15, 0, -0.1)</offset>
+						</dataSouth>
+					</drawData>
+				</li>
+			</renderNodeProperties>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]</xpath>
+		<value>
+			<li Class="CombatExtended.ShieldDefExtension">
+				<shieldCoverage>
+					<li>Hands</li>
+					<li>Arms</li>
+					<li>Shoulders</li>
+					<li>Torso</li>
+				</shieldCoverage>
+			</li>
+		</value>
 	</Operation>
 
 	<!-- ===== Tower Shield =====-->
+
+	<Operation Class="PatchOperationAttributeSet">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]</xpath>
+		<attribute>ParentName</attribute>
+		<value>ShieldBase</value>
+	</Operation>
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/equippedStatOffsets</xpath>
@@ -116,7 +165,6 @@
 		</value>
 	</Operation>
 
-	<!-- Mass & Bulk -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/Mass</xpath>
 		<value>
@@ -126,16 +174,13 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
-			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -143,13 +188,58 @@
 		</value>
 	</Operation>
 
-	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/apparel/layers</xpath>
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/apparel/drawData</xpath>
 		<value>
-			<layers>
-				<li>Shield</li>
-			</layers>
+			<renderNodeProperties>
+				<li>
+					<nodeClass>CombatExtended.PawnRenderNode_Apparel</nodeClass>
+					<workerClass>CombatExtended.PawnRenderNodeWorker_Drafted</workerClass>
+					<texPath>Things/Apparels/RiotShield/KerberosTowerShield</texPath>
+					<shaderTypeDef>CutoutComplex</shaderTypeDef>
+					<parentTagDef>ApparelBody</parentTagDef>
+					<drawData>
+						<scale>0.9</scale>
+						<defaultData>
+							<layer>80</layer>
+						</defaultData>
+						<dataEast>
+							<layer>-5</layer>
+							<offset>(0, 0, -0.1)</offset>
+							<rotationOffset>30</rotationOffset>
+						</dataEast>
+						<dataWest>
+							<rotationOffset>-30</rotationOffset>
+						</dataWest>
+						<dataNorth>
+							<layer>-5</layer>
+							<offset>(0.15, 0, 0)</offset>
+						</dataNorth>
+						<dataSouth>
+							<offset>(0.15, 0, 0)</offset>
+						</dataSouth>
+					</drawData>
+				</li>
+			</renderNodeProperties>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]</xpath>
+		<value>
+			<li Class="CombatExtended.ShieldDefExtension">
+				<shieldCoverage>
+					<li>Hands</li>
+					<li>Arms</li>
+					<li>Shoulders</li>
+					<li>Torso</li>
+					<li>Neck</li>
+					<li>FullHead</li>
+				</shieldCoverage>
+				<crouchCoverage>
+					<li>Legs</li>
+				</crouchCoverage>
+			</li>
 		</value>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -28,7 +28,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -37,7 +36,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -48,13 +46,15 @@
 	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/apparel/layers</xpath>
-		<value>
-			<li>Shield</li>
-		</value>
+			<value>	
+				<layers>
+					<li>Shield</li>
+				</layers>
+			</value>
 	</Operation>
 
 	<!-- ===== Combat Shield ===== -->
-	<!-- Equipped Stat Offsets -->
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/equippedStatOffsets</xpath>
 		<value>
@@ -68,7 +68,6 @@
 		</value>
 	</Operation>
 
-	<!-- Mass & Bulk -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/Mass</xpath>
 		<value>
@@ -78,7 +77,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -87,7 +85,6 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -95,16 +92,17 @@
 		</value>
 	</Operation>
 
-	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/apparel/layers</xpath>
-		<value>
-			<li>Shield</li>
-		</value>
+			<value>	
+				<layers>
+					<li>Shield</li>
+				</layers>
+			</value>
 	</Operation>
 
 	<!-- ===== Tower Shield =====-->
-	<!-- Equipped Stat Offsets -->
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/equippedStatOffsets</xpath>
 		<value>
@@ -149,7 +147,9 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/apparel/layers</xpath>
 		<value>
-			<li>Shield</li>
+			<layers>
+				<li>Shield</li>
+			</layers>
 		</value>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -1,18 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- =============================== Wrist Shield =============================================================================-->
+	<!-- ===== Wrist Shield ===== -->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/equippedStatOffsets</xpath>
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]</xpath>
 		<value>
-			<ReloadSpeed>-0.05</ReloadSpeed>
-			<MeleeHitChance>0</MeleeHitChance>
-			<ShootingAccuracyPawn>-0.1</ShootingAccuracyPawn>
-			<AimingAccuracy>-0.05</AimingAccuracy>
-			<Suppressability>-0.25</Suppressability>
-			<MeleeCritChance>-0.05</MeleeCritChance>
-			<MeleeParryChance>0.75</MeleeParryChance>
+			<equippedStatOffsets>
+				<ReloadSpeed>-0.05</ReloadSpeed>
+				<MeleeHitChance>0</MeleeHitChance>
+				<ShootingAccuracyPawn>-0.1</ShootingAccuracyPawn>
+				<AimingAccuracy>-0.05</AimingAccuracy>
+				<Suppressability>-0.25</Suppressability>
+				<MeleeCritChance>-0.05</MeleeCritChance>
+				<MeleeParryChance>0.75</MeleeParryChance>
+			</equippedStatOffsets>
+		</value>
+	</Operation>
+
+	<!-- Mass & Bulk -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/Mass</xpath>
+		<value>
+			<Mass>5</Mass>
+			<Bulk>3.5</Bulk>
+			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
 
@@ -22,9 +34,6 @@
 		<value>
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
 			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
-			<Mass>5</Mass>
-			<Bulk>3.5</Bulk>
-			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
 
@@ -33,7 +42,6 @@
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
 			<ArmorRating_Blunt>20</ArmorRating_Blunt>
-			
 		</value>
 	</Operation>
 
@@ -45,7 +53,7 @@
 		</value>
 	</Operation>
 
-	<!-- =============================== Combat Shield =============================================================================-->
+	<!-- ===== Combat Shield ===== -->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/equippedStatOffsets</xpath>
@@ -60,15 +68,22 @@
 		</value>
 	</Operation>
 
+	<!-- Mass & Bulk -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/Mass</xpath>
+		<value>
+			<Mass>9</Mass>
+			<Bulk>10</Bulk>
+			<WornBulk>7</WornBulk>
+		</value>
+	</Operation>
+
 	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>12</ArmorRating_Sharp>
 			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
-			<Mass>9</Mass>
-			<Bulk>10</Bulk>
-			<WornBulk>7</WornBulk>
 		</value>
 	</Operation>
 
@@ -88,7 +103,7 @@
 		</value>
 	</Operation>
 
-	<!-- =============================== Tower Shield =============================================================================-->
+	<!-- ===== Tower Shield =====-->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/equippedStatOffsets</xpath>
@@ -103,15 +118,22 @@
 		</value>
 	</Operation>
 
-	<!-- Armor Rating SHARP -->
+	<!-- Mass & Bulk -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/Mass</xpath>
+		<value>
+			<Mass>18</Mass>
+			<Bulk>17</Bulk>
+			<WornBulk>12</WornBulk>
+		</value>
+	</Operation>
+
+	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
-			<Mass>18</Mass>
-			<Bulk>17</Bulk>
-			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
 

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-    <!-- =============================== Wrist Shield =============================================================================-->
+
+	<!-- =============================== Wrist Shield =============================================================================-->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/equippedStatOffsets</xpath>
@@ -14,30 +15,28 @@
 			<MeleeParryChance>0.75</MeleeParryChance>
 		</value>
 	</Operation>
+
 	<!-- Armor Rating SHARP -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
 			<ArmorRating_Sharp>10</ArmorRating_Sharp>
-		</value>
-	</Operation>
-	<!-- Armor Rating BLUNT -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
-		<value>
-			<ArmorRating_Blunt>20</ArmorRating_Blunt>
-		</value>
-	</Operation>
-	<!-- Stat Bases -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases</xpath>
-		<value>
 			<StuffEffectMultiplierArmor>8</StuffEffectMultiplierArmor>
 			<Mass>5</Mass>
 			<Bulk>3.5</Bulk>
 			<WornBulk>2</WornBulk>
 		</value>
 	</Operation>
+
+	<!-- Armor Rating BLUNT -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/statBases/ArmorRating_Blunt</xpath>
+		<value>
+			<ArmorRating_Blunt>20</ArmorRating_Blunt>
+			
+		</value>
+	</Operation>
+
 	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_WristShield"]/apparel/layers</xpath>
@@ -45,6 +44,7 @@
 			<li>Shield</li>
 		</value>
 	</Operation>
+
 	<!-- =============================== Combat Shield =============================================================================-->
 	<!-- Equipped Stat Offsets -->
 	<Operation Class="PatchOperationAdd">
@@ -59,23 +59,19 @@
 			<MeleeParryChance>1.0</MeleeParryChance>
 		</value>
 	</Operation>
-	<!-- Stat Bases -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases</xpath>
+
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
+			<ArmorRating_Sharp>12</ArmorRating_Sharp>
 			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 			<Mass>9</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>7</WornBulk>
 		</value>
 	</Operation>
-	<!-- Armor Rating SHARP -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>12</ArmorRating_Sharp>
-		</value>
-	</Operation>
+
 	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Blunt</xpath>
@@ -83,6 +79,7 @@
 			<ArmorRating_Blunt>22</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/apparel/layers</xpath>
@@ -105,23 +102,19 @@
 			<MeleeParryChance>1.0</MeleeParryChance>
 		</value>
 	</Operation>
-	<!-- Stat Bases -->
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases</xpath>
+
+	<!-- Armor Rating SHARP -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
+			<ArmorRating_Sharp>14</ArmorRating_Sharp>
 			<StuffEffectMultiplierArmor>10</StuffEffectMultiplierArmor>
 			<Mass>18</Mass>
 			<Bulk>17</Bulk>
 			<WornBulk>12</WornBulk>
 		</value>
 	</Operation>
-	<!-- Armor Rating SHARP -->
-	<Operation Class="PatchOperationReplace">
-		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
-		<value>
-			<ArmorRating_Sharp>14</ArmorRating_Sharp>
-		</value>
-	</Operation>
+
 	<!-- Armor Rating BLUNT -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Blunt</xpath>
@@ -129,6 +122,7 @@
 			<ArmorRating_Blunt>26</ArmorRating_Blunt>
 		</value>
 	</Operation>
+
 	<!-- Layers -->
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/apparel/layers</xpath>
@@ -136,4 +130,5 @@
 			<li>Shield</li>
 		</value>
 	</Operation>
+
 </Patch>

--- a/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
+++ b/ModPatches/Kerberos Protect Gears and Firearms/Patches/Kerberos Protect Gears and Firearms/Wearables/Shields_Patches.xml
@@ -83,14 +83,14 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>8</ArmorRating_Sharp>
+			<ArmorRating_Sharp>6</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_CombatShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>12</ArmorRating_Blunt>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
 		</value>
 	</Operation>
 
@@ -168,23 +168,23 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/Mass</xpath>
 		<value>
-			<Mass>18</Mass>
-			<Bulk>17</Bulk>
-			<WornBulk>12</WornBulk>
+			<Mass>13</Mass>
+			<Bulk>15</Bulk>
+			<WornBulk>10</WornBulk>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Sharp</xpath>
 		<value>
-			<ArmorRating_Sharp>14</ArmorRating_Sharp>
+			<ArmorRating_Sharp>8</ArmorRating_Sharp>
 		</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Kerberos_TowerShield"]/statBases/ArmorRating_Blunt</xpath>
 		<value>
-			<ArmorRating_Blunt>26</ArmorRating_Blunt>
+			<ArmorRating_Blunt>12</ArmorRating_Blunt>
 		</value>
 	</Operation>
 

--- a/SupportedThirdPartyMods.md
+++ b/SupportedThirdPartyMods.md
@@ -299,6 +299,7 @@ Kaiser Armory	|
 Kemomimihouse |
 Kemomimihouse Kz |
 Kenshi Armory |
+Kerberos Protect Gears and Firearms	|
 K.L.K - Styles Apparel Pack	|
 Kijin Race 3.0     	|     
 Kill la Kill Styles Pack    |


### PR DESCRIPTION
Original Mod Author: BlackMarket420

## Additions

Patched real-world weapons: MG 34, MG 42, StG 44, Grenade Launcher Pistol (HK69A1), and Mauser C96 
Then also patched fictional power armors, heavy ammo packs, and power-armor integrated shields

## Reasoning

Why did you choose to implement things this way, e.g.
- Followed sheet for ranged weapons to calculate stats for all weapons
- Power Armors armor rating set to slightly more or on par with Recon armor as balanced with original mod
- Other power armor stats taken from another previously made patch for yet another Jin Roh armor mod
- Shields bulks based on buckler:wrist shield, assault shield:combat shield, Ballistic Shield:Tower Shield

## Alternatives

Describe alternative implementations you have considered, e.g.
- Power Armors:
  - Reduce effectiveness of power armors to better match claimed tech level of the power armor (in between flak and recon)
  - Mod author claims they're industrial armors, but have a high cost and vanilla balanced to spacer armors
  - Stuck with original intended power level

## Testing

Check tests you have performed:
- [x] Compiles without warnings
- [x] Game runs without errors
- [x] (For compatibility patches) ...with and without patched mod loaded
- [x] Playtested a colony (Several hours (8-12). Couple days of play with weapons. Only hour or so with Power Armors.)
